### PR TITLE
Solution versioning fix for FocusCenterPRChecker

### DIFF
--- a/Tools/FocusCenterPRChecker/FocusCenterPRChecker/ConnectionReferenceTool/Solution.cs
+++ b/Tools/FocusCenterPRChecker/FocusCenterPRChecker/ConnectionReferenceTool/Solution.cs
@@ -122,6 +122,12 @@ namespace FocusCenterPRChecker.ConnectionReferenceTool
                 string masterSolutionUrl = $"{ConfigManager.AzureDevOpsRepositoryUrl}/items?path={ConfigManager.SolutionsRepoPath}{solutionPath.Split('\\').LastOrDefault()}/Other/Solution.xml&api-version=6.0";
 
                 string masterSolutionFileContent = await HttpManager.SendGetRequest(masterSolutionUrl, "text/plain");
+
+                if (masterSolutionFileContent == null)
+                {
+                    return "";
+                }
+
                 var oldVersionString = XDocument.Parse(masterSolutionFileContent).Root.Descendants("Version").FirstOrDefault().Value;
 
                 var newVersion = Version.Parse(newVersionString);


### PR DESCRIPTION
Solution versioning validation is bypassed if a solution is committed for the first time.